### PR TITLE
fix: Offset cron timing to fit France timezone

### DIFF
--- a/.github/workflows/meta---pull-requests.yml
+++ b/.github/workflows/meta---pull-requests.yml
@@ -9,7 +9,7 @@ on:
         type: boolean
         default: true
   schedule:
-    - cron:  '0 8,13 * * 1,2,3,4,5'
+    - cron:  '0 7,12 * * 1,2,3,4,5'
 
 jobs:
   fetch-prs:


### PR DESCRIPTION
We want the job to be executed at 8AM and 1PM on France timezone

However we should find a way to automatically adapt to summer/winter time in the future